### PR TITLE
pass None for the oof sound during generation.

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -403,6 +403,7 @@ class ALTTPWorld(World):
                                world.menuspeed[player].current_key,
                                world.music[player],
                                world.sprite[player],
+                               None,
                                palettes_options, world, player, True,
                                reduceflashing=world.reduceflashing[player] or world.is_race,
                                triforcehud=world.triforcehud[player].current_key,


### PR DESCRIPTION
Just deleting that key but calling the function anyways cause all of the args to be in incorrect positions. Passing None so that it doesn't attempt to patch the oof sound during generation. Tested by patching both a prepatched rom and with the bsdiff and both worked as expected. Only other thing I would like is a direct link to the default sound on your github in the doc as that gives a working example and it defaults to nothing in the adjuster. Sorry you had to wait so long for this but thanks for doing this.